### PR TITLE
chore(package): bump to coffeescript 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-register": "^6.5.2",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "coffee-script": "^1.10.0",
+    "coffeescript": "^2.3.2",
     "del": "^3.0.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",


### PR DESCRIPTION
## Purpose

* Update coffee script version
* Fix warning log

## Detail

Now we are using coffee-script 1.10.0 and it version appear warning log like this.

```sh
[11:07:40] Failed to load external module coffeescript/register
```

The reason of error, the coffee script npm repository was changed [since 1.12.6](https://github.com/jashkenas/coffeescript/pull/4548/files#diff-04c6e90faac2675aa89e2176d2eec7d8).